### PR TITLE
Support --oneshot and --id, wait on signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .eggs/
 src/canScan.egg-info/
 src/canscan/__pycache__/
+*.pyc

--- a/src/canscan/__main__.py
+++ b/src/canscan/__main__.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 import node
+import signal
 import argparse
 
 if __name__ == '__main__':
@@ -14,7 +15,7 @@ if __name__ == '__main__':
     parser.add_argument('--scansdo', help='comma-delimited list of nodes to scan',
                         type=lambda x: x.split(','))
     args = parser.parse_args()
-    node.Node(args.device)
+    CanNode = node.Node(args.device)
     scanNodes = []
     scanSet = set(scanNodes)
     if args.scansdo:
@@ -38,3 +39,6 @@ if __name__ == '__main__':
                 scanSet.update(r)
         scanNodes = list(scanSet)
     print('Node scan list:', scanNodes)
+    CanNode.NetworkSDOSweep()
+    CanNode.Discover()
+    signal.pause()

--- a/src/canscan/__main__.py
+++ b/src/canscan/__main__.py
@@ -13,7 +13,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Probe and listen for CANopen')
     parser.add_argument('device', help='link/can network device')
     parser.add_argument('--scansdo', help='comma-delimited list of nodes to scan',
-                        type=lambda x: x.split(','))
+                        type=lambda x: x.split(','), default=[])
+    parser.add_argument('--oneshot', help='do an active scan, dump results, and exit',
+                        action='store_true', dest='oneshot')
     args = parser.parse_args()
     CanNode = node.Node(args.device)
     scanNodes = []
@@ -41,4 +43,6 @@ if __name__ == '__main__':
     print('Node scan list:', scanNodes)
     CanNode.NetworkSDOSweep()
     CanNode.Discover()
-    signal.pause()
+    if not args.oneshot:
+        print('Waiting for signal/keyboard interrupt...')
+        signal.pause()

--- a/src/canscan/node.py
+++ b/src/canscan/node.py
@@ -7,10 +7,21 @@ class Node(object):
     """CANopen node bound to some device"""
 
     def __init__(self, dev):
-        network = canopen.Network()
-        network.connect(bustype='socketcan', channel=dev)
+        self.network = canopen.Network()
+        self.network.connect(bustype='socketcan', channel=dev)
+
+    def __del__(self):
+        print("Disconnecting from CAN...")
+        self.network.disconnect()
 
     def CheckNodeSDO(self, nodeid):
         """Hit some node (7-bit Node ID) with a quick Vendor Identity SDO."""
         node = canopen.RemoteNode(6)
         vendor_id = node.sdo[OD_IDENTITY][OD_IDENTITY_VENDORID].raw
+
+    def NetworkSDOSweep(self):
+        """Use python-canopen's inflexible SDO search."""
+        self.network.scanner.search()
+
+    def Discover(self):
+        """Listen for traffic identifying CANopen nodes. FIXME"""


### PR DESCRIPTION
* Wait on keyboard interrupt unless `--oneshot` is provided
* Allow CANopen node ID to be specified with `--id`, otherwise default is 0x64